### PR TITLE
chore: enforce pnpm supply-chain hardening

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+minimum-release-age=1440
+minimum-release-age-exclude[]=@tryriot/*
+block-exotic-subdeps=true


### PR DESCRIPTION
## Why

Recent npm supply-chain attacks (maintainer compromises pushing malicious versions within hours) make installing brand-new releases risky. A short release-age delay catches most of these before they reach our installs, while exempting `@tryriot/*` keeps internal package iteration fast. Blocking exotic transitive sources closes the side-door where a clean direct dependency pulls a tarball/git URL we never reviewed.